### PR TITLE
fix: update goreleaser install link to use gist

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -36,7 +36,7 @@ global_job_config:
       - cat /home/semaphore/datas/traefiker-keyfile.json | docker login -u _json_key --password-stdin https://gcr.io
       - echo "${DOCKERHUB_PASSWORD}" | docker login -u "${DOCKERHUB_USERNAME}" --password-stdin
       - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${GOPATH}/bin" v1.40.1
-      - curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | bash -s -- -b "${GOPATH}/bin"
+      - curl -sfL https://gist.githubusercontent.com/traefiker/6d7ac019c11d011e4f131bb2cca8900e/raw/goreleaser.sh | bash -s -- -b "${GOPATH}/bin"
       - checkout
       - cache restore "mod-${SEMAPHORE_PROJECT_NAME}-${SEMAPHORE_GIT_BRANCH}-$(checksum go.mod),mod-${SEMAPHORE_PROJECT_NAME}-$(checksum go.mod),mod-${SEMAPHORE_PROJECT_NAME}"
       - make start-local-db


### PR DESCRIPTION
### What does this PR do?

Since the recent release of [goreleaser](https://goreleaser.com) [v1.2.1](https://github.com/goreleaser/goreleaser/releases/tag/v1.2.1), the script to install it was removed.

This PR update the script to install goreleaser to use a gist instead.

### Motivation

Have a working CI.
