### PR TITLE
:bug: ignore module case as github does

### DIFF
--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -125,17 +125,7 @@ func (h Handlers) List(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	// TODO: detection of the plugin name changes must be done in piceus.
-	var cleanPlugins []db.Plugin
-	for _, plugin := range plugins {
-		if plugin.Name == "github.com/tommoulard/fail2ban" || plugin.Name == "github.com/tommoulard/htransformation" {
-			continue
-		}
-
-		cleanPlugins = append(cleanPlugins, plugin)
-	}
-
-	if len(cleanPlugins) == 0 {
+	if len(plugins) == 0 {
 		if err := json.NewEncoder(rw).Encode(make([]*db.Plugin, 0)); err != nil {
 			span.RecordError(err)
 			logger.Error().Err(err).Msg("Failed to encode response")
@@ -146,7 +136,7 @@ func (h Handlers) List(rw http.ResponseWriter, req *http.Request) {
 
 	rw.Header().Set(nextPageHeader, next)
 
-	if err := json.NewEncoder(rw).Encode(cleanPlugins); err != nil {
+	if err := json.NewEncoder(rw).Encode(plugins); err != nil {
 		span.RecordError(err)
 		logger.Error().Err(err).Msg("Failed to encode response")
 		JSONInternalServerError(rw)
@@ -335,6 +325,7 @@ func (h Handlers) getByName(rw http.ResponseWriter, req *http.Request) {
 	defer span.End()
 
 	name := unquote(req.FormValue("name"))
+	name = cleanModuleName(name)
 
 	logger := log.With().Str("module_name", name).Logger()
 

--- a/pkg/handlers/handlers_test.go
+++ b/pkg/handlers/handlers_test.go
@@ -90,6 +90,7 @@ func TestHandlers_List_GetByName(t *testing.T) {
 
 	testDB := mockDB{
 		getByNameFn: func(ctx context.Context, query string) (db.Plugin, error) {
+			assert.Equal(t, query, "demo plugin")
 			return data, nil
 		},
 	}

--- a/pkg/handlers/module.go
+++ b/pkg/handlers/module.go
@@ -316,5 +316,5 @@ func (h Handlers) Validate(rw http.ResponseWriter, req *http.Request) {
 }
 
 func cleanModuleName(moduleName string) string {
-	return strings.TrimSuffix(strings.TrimPrefix(moduleName, "/"), "/")
+	return strings.ToLower(strings.TrimSuffix(strings.TrimPrefix(moduleName, "/"), "/"))
 }

--- a/pkg/handlers/module_test.go
+++ b/pkg/handlers/module_test.go
@@ -33,6 +33,10 @@ func Test_cleanModuleName(t *testing.T) {
 			name:     "powpow/v2/",
 			expected: "powpow/v2",
 		},
+		{
+			name:     "PowPow/v2/",
+			expected: "powpow/v2",
+		},
 	}
 
 	for _, test := range testCases {


### PR DESCRIPTION
A lot of users can't download plugins because the owner name in path has been renamed.
example [here](https://traefiklabs.grafana.net/explore?orgId=1&left=%7B%22datasource%22:%22traefiklabs-logs%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%7Bcluster%3D%5C%22p00-euw3-eks-platform%5C%22,%20namespace%3D%5C%22plugin-catalog%5C%22,%20app%3D%5C%22plugin-service%5C%22%7D%22,%22queryType%22:%22range%22%7D%5D,%22range%22:%7B%22from%22:%221658732229664%22,%22to%22:%221658736825929%22%7D%7D)
github.com/tommoulard/fail2ban can be accessed from any of those urls:
- github.com/tommoulard/fail2ban
- github.com/tOmMouLard/fail2ban
- ...