### PR TITLE
chore: update CI machine type and base OS

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -2,8 +2,8 @@ version: v1.0
 name: Plugin service
 agent:
   machine:
-    type: e1-standard-4
-    os_image: ubuntu1804
+    type: e1-standard-2
+    os_image: ubuntu2004
 fail_fast:
   stop:
     when: "branch != 'master'"


### PR DESCRIPTION
### What does this PR do?

1. Update OS image used by semaphore to Ubuntu 20.04
2. Reduce machine type from e1-standard-4 to e1-standard-2

### Motivation

See https://github.com/traefik/infra/issues/3859
