### PR TITLE
Use GitHub for wasm plugin instead of go proxy

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -7,6 +7,8 @@ type Plugin struct {
 	ID            string                 `json:"id,omitempty" bson:"id"`
 	Name          string                 `json:"name,omitempty" bson:"name"`
 	DisplayName   string                 `json:"displayName,omitempty" bson:"displayName"`
+	Runtime       string                 `json:"runtime,omitempty" bson:"runtime"`
+	WasmPath      string                 `json:"wasmPath,omitempty" bson:"wasmPath"`
 	Author        string                 `json:"author,omitempty" bson:"author"`
 	Type          string                 `json:"type,omitempty" bson:"type"`
 	Import        string                 `json:"import,omitempty" bson:"import"`

--- a/pkg/handlers/module.go
+++ b/pkg/handlers/module.go
@@ -40,7 +40,7 @@ func (h Handlers) Download(rw http.ResponseWriter, req *http.Request) {
 
 	logger := log.With().Str("module_name", moduleName).Str("module_version", version).Logger()
 
-	_, err := h.store.GetByName(ctx, moduleName, false)
+	plugin, err := h.store.GetByName(ctx, moduleName, false)
 	if err != nil {
 		span.RecordError(err)
 		if errors.As(err, &db.NotFoundError{}) {
@@ -88,7 +88,7 @@ func (h Handlers) Download(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if h.gh != nil && len(modFile.Require) > 0 {
+	if h.gh != nil && (len(modFile.Require) > 0 || plugin.Runtime == "wasm") {
 		h.downloadGitHub(ctx, moduleName, version)(rw, req)
 		return
 	}


### PR DESCRIPTION
This PR modify the behaviour for wasm plugin. It forces to download the plugin by using github instead of using the goproxy, in order to have the wasm file.