### PR TITLE
chore(ci): update go proxy access

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -32,7 +32,7 @@ global_job_config:
       - export "SEMAPHORE_GIT_DIR=${GOPATH}/src/github.com/traefik/${SEMAPHORE_PROJECT_NAME}"
       - export "PATH=${GOPATH}/bin:${PATH}"
       - mkdir -vp "${SEMAPHORE_GIT_DIR}" "${GOPATH}/bin"
-      - export GOPROXY=https://gomod.traefiklabs.tech,https://proxy.golang.org,direct
+      - export GOPROXY=https://goproxy.io,https://athens.traefiklabs.tech,direct
       - cat /home/semaphore/datas/traefiker-keyfile.json | docker login -u _json_key --password-stdin https://gcr.io
       - echo "${DOCKERHUB_PASSWORD}" | docker login -u "${DOCKERHUB_USERNAME}" --password-stdin
       - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${GOPATH}/bin" v1.59.1


### PR DESCRIPTION
# Motivation

Credentials has been updated on Traefik EE Semaphore org , following https://github.com/traefik/infra/issues/6603
CI needs to be updated accordingly.