### PR TITLE
fix: pr build

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -80,7 +80,7 @@ blocks:
         - name: Run build
           commands:
             - make
-            - make multi-arch-image-${SEMAPHORE_GIT_PR_NUMBER}
+            - make multi-arch-image-pr-${SEMAPHORE_GIT_PR_NUMBER}
 
   - name: Tag - Build release
     dependencies: ["Warm cache"]


### PR DESCRIPTION
# Motivation

Current build is not following naming convention
As a consequence, the cleaner delete tagged image