### PR TITLE
fix: pin alpine base image, run as non-root, harden checkout credentials

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,8 @@ jobs:
       GOLANGCI_LINT_VERSION: 'v2.3.0'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: 'go.mod'
@@ -48,6 +50,8 @@ jobs:
     if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.draft }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: 'go.mod'
@@ -69,6 +73,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: 'go.mod'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
-FROM alpine
+FROM alpine:3.24.1
 
 RUN apk --no-cache --no-progress add git ca-certificates tzdata make \
     && update-ca-certificates \
     && rm -rf /var/cache/apk/*
 
 COPY ./dist/linux/amd64/plugin-service .
+
+USER 65534
 
 ENTRYPOINT ["/plugin-service"]
 EXPOSE 80

--- a/buildx.Dockerfile
+++ b/buildx.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.24.1
 
 RUN apk --no-cache --no-progress add git ca-certificates tzdata make \
     && update-ca-certificates \
@@ -6,6 +6,8 @@ RUN apk --no-cache --no-progress add git ca-certificates tzdata make \
 
 ARG TARGETPLATFORM
 COPY ./dist/$TARGETPLATFORM/plugin-service .
+
+USER 65534
 
 ENTRYPOINT ["/plugin-service"]
 EXPOSE 80


### PR DESCRIPTION
### Motivation

Resolve plugin-service's Aikido IaC findings and harden CI checkout credentials. Both Dockerfiles used `FROM alpine` (unpinned `latest`) and ran as root; they now pin the alpine base to a concrete version and run as user `65534` (nobody). The CI `actions/checkout` steps set `persist-credentials: false` so the GitHub token is no longer left in `.git/config`.

- Docker container runs as root: https://app.aikido.dev/queue?issue_id_filter=18158985
- Automatic upgrades of base Docker images: https://app.aikido.dev/queue?issue_id_filter=18158999
- actions/checkout persists Git credentials: https://app.aikido.dev/queue?issue_id_filter=33654896
